### PR TITLE
fix multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # ---------- Build stage ----------
 FROM alpine:3.22.1 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# Do not specify default value as docker buildx will not set the arguments otherwise, see https://github.com/docker/buildx/issues/510
+ARG TARGETOS
+ARG TARGETARCH
+
 ARG KUBECTL_VERSION=v1.33.4
 ARG HELM_VERSION=v3.18.5
 ARG KUSTOMIZE_VERSION=v5.7.1


### PR DESCRIPTION
The changes to the Dockerfile in fcf5008cf81ac5c07e0612df776287c14672ae13 caused multi-platform builds to break, always defaulting to linux/amd64 binaries. The arm64 version of `docker.io/kubesphere/kubectl:v1.33.4` is currently broken and usage of any of the installed tools leads to a `exec format error`.

A new version of the image with kubectl 1.34 would also be appreciated :smile: 